### PR TITLE
feat(favorite): cải thiện giao diện và tương tác màn Yêu thích

### DIFF
--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/auth/PasscodeActivity.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/auth/PasscodeActivity.java
@@ -161,7 +161,7 @@ public class PasscodeActivity extends AppCompatActivity {
         new android.os.Handler().postDelayed(() -> {
             isChecking = false; // Mở khóa trạng thái
             SessionManager sessionManager = SessionManager.getInstance(PasscodeActivity.this);
-            sessionManager.createLoginSession(1, "mock_token", "Mock User", phoneNumber, "");
+            sessionManager.createLoginSession(1L, "mock_token", "Mock User", phoneNumber, "");
 
             Toast.makeText(PasscodeActivity.this, "Đăng nhập thành công!", Toast.LENGTH_SHORT).show();
             Intent intent = new Intent(PasscodeActivity.this, HomeActivity.class);

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteActivity.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteActivity.java
@@ -13,11 +13,14 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.example.uitpayapp.R;
 import com.google.android.material.tabs.TabLayout;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import com.example.uitpayapp.home.HomeActivity;
+import com.example.uitpayapp.home.home_models.Restaurant;
 
 public class FavoriteActivity extends AppCompatActivity {
 
@@ -25,6 +28,7 @@ public class FavoriteActivity extends AppCompatActivity {
     private TextView tvFilterService;
     private View layoutEmptyState;
     private RecyclerView rvMainFavorite;
+    private SwipeRefreshLayout swipeRefreshLayout;
     private FavoriteMainAdapter mainAdapter;
 
     private List<FavoriteShop> baseShops;        // Danh sách gốc từ DB
@@ -51,11 +55,21 @@ public class FavoriteActivity extends AppCompatActivity {
         tvFilterService = findViewById(R.id.tvFilterService);
         layoutEmptyState = findViewById(R.id.layoutEmptyState);
         rvMainFavorite = findViewById(R.id.rvMainFavorite);
+        swipeRefreshLayout = findViewById(R.id.swipeRefreshLayout);
+
+        swipeRefreshLayout.setOnRefreshListener(() -> {
+            loadDatabaseShops();
+            applyFilterAndSorting();
+            swipeRefreshLayout.setRefreshing(false);
+        });
 
         loadDatabaseShops();
 
         filteredShops = new ArrayList<>(baseShops);
-        mainAdapter = new FavoriteMainAdapter(filteredShops, topOrderedShops);
+        mainAdapter = new FavoriteMainAdapter(filteredShops, topOrderedShops, shop -> {
+            shop.setFavorited(!shop.isFavorited());
+            mainAdapter.notifyDataSetChanged();
+        });
         rvMainFavorite.setAdapter(mainAdapter);
         rvMainFavorite.setLayoutManager(new LinearLayoutManager(this));
 
@@ -65,20 +79,53 @@ public class FavoriteActivity extends AppCompatActivity {
         setupBottomNavigation();
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (mainAdapter != null) {
+            loadDatabaseShops();
+            applyFilterAndSorting();
+        }
+    }
+
     private void loadDatabaseShops() {
-        baseShops = new ArrayList<>();
-        topOrderedShops = new ArrayList<>();
+        if (baseShops == null) {
+            baseShops = new ArrayList<>();
+        } else {
+            baseShops.clear();
+        }
+        
+        if (topOrderedShops == null) {
+            topOrderedShops = new ArrayList<>();
+        } else {
+            topOrderedShops.clear();
+        }
 
-        // Thêm dữ liệu mô phỏng quán ăn
-        baseShops.add(new FavoriteShop("1", "Cơm Chiên Dương Châu & Mì Trộn Tóp Mỡ", 4.7, 3.5, 27, android.R.drawable.ic_menu_report_image, "Mã giảm 19%", "Đồ ăn", 200));
-        baseShops.add(new FavoriteShop("2", "Banchan House - Quán Ăn Hàn Quốc", 4.4, 0.4, 22, android.R.drawable.ic_menu_report_image, "Mã giảm 19%", "Đồ ăn", 180));
-        baseShops.add(new FavoriteShop("3", "TIỆM BÚN A NHỬU - BÚN THÁI", 4.5, 1.2, 15, android.R.drawable.ic_menu_report_image, "Flash Sale", "Đồ ăn", 140));
-        baseShops.add(new FavoriteShop("4", "Siêu Thị Lotte Mart - Nguyễn Hữu Thọ", 4.6, 2.1, 30, android.R.drawable.ic_menu_report_image, "Mã giảm 10%", "Siêu thị", 40));
-
-        // Nạp riêng các quán có lượt đặt cao vào mục Ngang
-        for (FavoriteShop shop : baseShops) {
-            if (shop.getOrderCount() >= 100) {
-                topOrderedShops.add(shop);
+        List<Restaurant> restaurants = HomeActivity.HomeRepository.getInstance().getRestaurants();
+        for (int i = 0; i < restaurants.size(); i++) {
+            Restaurant r = restaurants.get(i);
+            
+            // Generate a random distance since Restaurant doesn't have it
+            double distance = 0.5 + (Math.random() * 5.0);
+            distance = Math.round(distance * 10.0) / 10.0;
+            
+            int orderCount = 50 + (i * 20); // Giả lập lượt đặt
+            
+            FavoriteShop fs = new FavoriteShop(
+                String.valueOf(i), 
+                r.getName(), 
+                r.getRating(), 
+                distance, 
+                r.getDeliveryTime(), 
+                r.getImageResId(), 
+                "Mã giảm " + (10 + (i % 3) * 5) + "%", 
+                r.getCategory(), 
+                orderCount
+            );
+            baseShops.add(fs);
+            
+            if (orderCount >= 100) {
+                topOrderedShops.add(fs);
             }
         }
     }
@@ -101,31 +148,54 @@ public class FavoriteActivity extends AppCompatActivity {
     }
 
     private void setupDropdownFilters() {
-        tvFilterService.setOnClickListener(v -> {
-            PopupMenu popup = new PopupMenu(this, v);
-            popup.getMenu().add("Dịch vụ"); // Hiển thị tất cả
-            popup.getMenu().add("Đồ ăn");
-            popup.getMenu().add("Thực phẩm");
-            popup.getMenu().add("Rượu bia");
-            popup.getMenu().add("Hoa");
-            popup.getMenu().add("Siêu thị");
-
-            popup.setOnMenuItemClickListener(item -> {
-                currentCategory = item.getTitle().toString();
-                tvFilterService.setText(currentCategory + " ∨");
-                applyFilterAndSorting();
-                return true;
-            });
-            popup.show();
+        String[] categories = {"Tất cả", "Cơm", "Bún Phở", "Bánh mì", "Fastfood", "Lẩu", "Đồ nướng", "Cafe", "Trà sữa", "Ăn vặt", "Tráng miệng", "Hải sản", "Chay", "Đồ uống", "Gà rán", "Pizza"};
+        
+        android.widget.ArrayAdapter<String> adapter = new android.widget.ArrayAdapter<>(this, android.R.layout.simple_list_item_1, categories);
+        
+        android.widget.ListPopupWindow listPopupWindow = new android.widget.ListPopupWindow(this);
+        listPopupWindow.setAdapter(adapter);
+        listPopupWindow.setAnchorView(tvFilterService);
+        listPopupWindow.setWidth((int) (150 * getResources().getDisplayMetrics().density));
+        listPopupWindow.setHeight((int) (200 * getResources().getDisplayMetrics().density));
+        
+        listPopupWindow.setOnItemClickListener((parent, view, position, id) -> {
+            currentCategory = categories[position];
+            if (currentCategory.equals("Tất cả")) {
+                tvFilterService.setText("Tất cả ▼");
+            } else {
+                tvFilterService.setText(currentCategory + " ▼");
+            }
+            applyFilterAndSorting();
+            listPopupWindow.dismiss();
         });
+
+        tvFilterService.setOnClickListener(v -> {
+            listPopupWindow.show();
+        });
+        tvFilterService.setText("Tất cả ▼");
     }
 
     private void applyFilterAndSorting() {
+        // Xóa hẳn các shop đã bị unfavorite khi chuyển tab hoặc filter
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            baseShops.removeIf(shop -> !shop.isFavorited());
+            topOrderedShops.removeIf(shop -> !shop.isFavorited());
+        } else {
+            java.util.Iterator<FavoriteShop> it = baseShops.iterator();
+            while (it.hasNext()) {
+                if (!it.next().isFavorited()) it.remove();
+            }
+            java.util.Iterator<FavoriteShop> it2 = topOrderedShops.iterator();
+            while (it2.hasNext()) {
+                if (!it2.next().isFavorited()) it2.remove();
+            }
+        }
+
         filteredShops.clear();
 
         // 1. Thực hiện Lọc theo danh mục dịch vụ chọn từ Dropdown (Ảnh 2)
         for (FavoriteShop shop : baseShops) {
-            if (currentCategory.equals("Dịch vụ") || shop.getServiceType().equalsIgnoreCase(currentCategory)) {
+            if (currentCategory.equals("Dịch vụ") || currentCategory.equals("Tất cả") || shop.getServiceType().equalsIgnoreCase(currentCategory)) {
                 filteredShops.add(shop);
             }
         }

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteHorizontalAdapter.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteHorizontalAdapter.java
@@ -12,10 +12,16 @@ import java.util.List;
 
 public class FavoriteHorizontalAdapter extends RecyclerView.Adapter<FavoriteHorizontalAdapter.HorizontalViewHolder> {
 
-    private List<FavoriteShop> shopList;
+    public interface OnFavoriteRemoveListener {
+        void onRemove(FavoriteShop shop);
+    }
 
-    public FavoriteHorizontalAdapter(List<FavoriteShop> shopList) {
+    private List<FavoriteShop> shopList;
+    private OnFavoriteRemoveListener removeListener;
+
+    public FavoriteHorizontalAdapter(List<FavoriteShop> shopList, OnFavoriteRemoveListener removeListener) {
         this.shopList = shopList;
+        this.removeListener = removeListener;
     }
 
     @NonNull
@@ -30,8 +36,19 @@ public class FavoriteHorizontalAdapter extends RecyclerView.Adapter<FavoriteHori
         FavoriteShop shop = shopList.get(position);
 
         holder.tvHorizontalName.setText(shop.getName());
-        holder.tvHorizontalDiscount.setText(shop.getDiscountTag());
         holder.ivHorizontalImage.setImageResource(shop.getImageResId());
+
+        if (shop.isFavorited()) {
+            holder.ivHorizontalFavoriteHeart.setImageResource(R.drawable.favorite_filled_24px);
+        } else {
+            holder.ivHorizontalFavoriteHeart.setImageResource(R.drawable.favorite_border_24px);
+        }
+
+        holder.ivHorizontalFavoriteHeart.setOnClickListener(v -> {
+            if (removeListener != null) {
+                removeListener.onRemove(shop);
+            }
+        });
     }
 
     @Override
@@ -40,14 +57,14 @@ public class FavoriteHorizontalAdapter extends RecyclerView.Adapter<FavoriteHori
     }
 
     static class HorizontalViewHolder extends RecyclerView.ViewHolder {
-        TextView tvHorizontalName, tvHorizontalDiscount;
-        ImageView ivHorizontalImage;
+        TextView tvHorizontalName;
+        ImageView ivHorizontalImage, ivHorizontalFavoriteHeart;
 
         public HorizontalViewHolder(@NonNull View itemView) {
             super(itemView);
             tvHorizontalName = itemView.findViewById(R.id.tvHorizontalName);
-            tvHorizontalDiscount = itemView.findViewById(R.id.tvHorizontalDiscount);
             ivHorizontalImage = itemView.findViewById(R.id.ivHorizontalImage);
+            ivHorizontalFavoriteHeart = itemView.findViewById(R.id.ivHorizontalFavoriteHeart);
         }
     }
 }

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteMainAdapter.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteMainAdapter.java
@@ -19,10 +19,12 @@ public class FavoriteMainAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
     private List<FavoriteShop> verticalShops;
     private List<FavoriteShop> horizontalShops;
+    private FavoriteHorizontalAdapter.OnFavoriteRemoveListener removeListener;
 
-    public FavoriteMainAdapter(List<FavoriteShop> verticalShops, List<FavoriteShop> horizontalShops) {
+    public FavoriteMainAdapter(List<FavoriteShop> verticalShops, List<FavoriteShop> horizontalShops, FavoriteHorizontalAdapter.OnFavoriteRemoveListener removeListener) {
         this.verticalShops = verticalShops;
         this.horizontalShops = horizontalShops;
+        this.removeListener = removeListener;
     }
 
     @Override
@@ -87,7 +89,7 @@ public class FavoriteMainAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 ));
 
                 // Khởi tạo và gắn Adapter con xử lý cuộn ngang
-                FavoriteHorizontalAdapter subAdapter = new FavoriteHorizontalAdapter(horizontalShops);
+                FavoriteHorizontalAdapter subAdapter = new FavoriteHorizontalAdapter(horizontalShops, removeListener);
                 hvh.rvHorizontal.setAdapter(subAdapter);
                 hvh.rvHorizontal.setLayoutManager(new LinearLayoutManager(holder.itemView.getContext(), LinearLayoutManager.HORIZONTAL, false));
             }
@@ -103,6 +105,18 @@ public class FavoriteMainAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             vsh.tvInfo.setText("⭐ " + shop.getRating() + "  |  " + shop.getDistance() + "km  |  " + shop.getDeliveryTime() + "phút");
             vsh.tvDiscount.setText(shop.getDiscountTag());
             vsh.ivImage.setImageResource(shop.getImageResId());
+
+            if (shop.isFavorited()) {
+                vsh.ivFavoriteHeart.setImageResource(R.drawable.favorite_filled_24px);
+            } else {
+                vsh.ivFavoriteHeart.setImageResource(R.drawable.favorite_border_24px);
+            }
+
+            vsh.ivFavoriteHeart.setOnClickListener(v -> {
+                if (removeListener != null) {
+                    removeListener.onRemove(shop);
+                }
+            });
         }
     }
 
@@ -124,13 +138,14 @@ public class FavoriteMainAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
     static class VerticalShopViewHolder extends RecyclerView.ViewHolder {
         TextView tvName, tvInfo, tvDiscount;
-        ImageView ivImage;
+        ImageView ivImage, ivFavoriteHeart;
         public VerticalShopViewHolder(@NonNull View itemView) {
             super(itemView);
             tvName = itemView.findViewById(R.id.tvVerticalName);
             tvInfo = itemView.findViewById(R.id.tvVerticalInfo);
             tvDiscount = itemView.findViewById(R.id.tvVerticalDiscount);
             ivImage = itemView.findViewById(R.id.ivVerticalImage);
+            ivFavoriteHeart = itemView.findViewById(R.id.ivVerticalFavoriteHeart);
         }
     }
 

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteShop.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/favorite/FavoriteShop.java
@@ -10,6 +10,7 @@ public class FavoriteShop {
     private String discountTag;
     private String serviceType; // Đồ ăn, Thực phẩm, Rượu bia, Hoa, Siêu thị
     private int orderCount; // Số lượng đặt để xếp vào cụm "Đặt Nhiều Nhất"
+    private boolean isFavorited = true; // Theo dõi trạng thái yêu thích
 
     public FavoriteShop(String id, String name, double rating, double distance, int deliveryTime, int imageResId, String discountTag, String serviceType, int orderCount) {
         this.id = id;
@@ -33,4 +34,7 @@ public class FavoriteShop {
     public String getDiscountTag() { return discountTag; }
     public String getServiceType() { return serviceType; }
     public int getOrderCount() { return orderCount; }
+    
+    public boolean isFavorited() { return isFavorited; }
+    public void setFavorited(boolean favorited) { isFavorited = favorited; }
 }

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/history/RecommendedShopAdapter.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/history/RecommendedShopAdapter.java
@@ -37,15 +37,15 @@ public class RecommendedShopAdapter extends RecyclerView.Adapter<RecommendedShop
 
         // LOGIC TÁI SỬ DỤNG: Khối gợi ý thì ẩn tính năng yêu thích đi
         holder.tvFavoriteBadge.setVisibility(View.GONE);
-        holder.tvFavoriteHeart.setVisibility(View.GONE);
+        holder.ivFavoriteHeart.setVisibility(View.GONE);
     }
 
     @Override
     public int getItemCount() { return list.size(); }
 
     static class ViewHolder extends RecyclerView.ViewHolder {
-        TextView tvName, tvInfo, tvDiscount, tvFavoriteBadge, tvFavoriteHeart;
-        ImageView ivImage;
+        TextView tvName, tvInfo, tvDiscount, tvFavoriteBadge;
+        ImageView ivImage, ivFavoriteHeart;
 
         ViewHolder(View itemView) {
             super(itemView);
@@ -54,7 +54,7 @@ public class RecommendedShopAdapter extends RecyclerView.Adapter<RecommendedShop
             tvInfo = itemView.findViewById(R.id.tvVerticalInfo);
             tvDiscount = itemView.findViewById(R.id.tvVerticalDiscount);
             tvFavoriteBadge = itemView.findViewById(R.id.tvFavoriteBadge);
-            tvFavoriteHeart = itemView.findViewById(R.id.tvFavoriteHeart);
+            ivFavoriteHeart = itemView.findViewById(R.id.ivVerticalFavoriteHeart);
             ivImage = itemView.findViewById(R.id.ivVerticalImage);
         }
     }

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/home/HomeActivity.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/home/HomeActivity.java
@@ -141,9 +141,7 @@ public class HomeActivity extends AppCompatActivity {
         setupRestaurants();
         setupCategories();
         setupSearch();
-        setupTopics();
-        setupFlashsale();
-        setupBrands();
+        setupDeals();
         setupDeals();
         setupStickyTab();
         setupBottomNavigation();
@@ -162,47 +160,85 @@ public class HomeActivity extends AppCompatActivity {
 
     private void setupObservers() {
         viewModel.getCoreData().observe(this, state -> {
-            View errorView = findViewById(R.id.layout_core_error);
-            View flashsale = findViewById(R.id.flashsale_section);
-            View topic1 = findViewById(R.id.topic_section_1);
-            View topic2 = findViewById(R.id.topic_section_2);
+            View fsLoading = findViewById(R.id.layout_flashsale_loading);
+            View fsError = findViewById(R.id.layout_flashsale_error);
+            View fsSection = findViewById(R.id.flashsale_section);
+            
+            View t1Loading = findViewById(R.id.layout_topic1_loading);
+            View t1Error = findViewById(R.id.layout_topic1_error);
+            View t1Section = findViewById(R.id.topic_section_1);
+            
+            View t2Loading = findViewById(R.id.layout_topic2_loading);
+            View t2Error = findViewById(R.id.layout_topic2_error);
+            View t2Section = findViewById(R.id.topic_section_2);
 
             if (state.isLoading()) {
-                // Show loading
+                if (fsLoading != null) fsLoading.setVisibility(View.VISIBLE);
+                if (fsError != null) fsError.setVisibility(View.GONE);
+                if (fsSection != null) fsSection.setVisibility(View.GONE);
+                
+                if (t1Loading != null) t1Loading.setVisibility(View.VISIBLE);
+                if (t1Error != null) t1Error.setVisibility(View.GONE);
+                if (t1Section != null) t1Section.setVisibility(View.GONE);
+                
+                if (t2Loading != null) t2Loading.setVisibility(View.VISIBLE);
+                if (t2Error != null) t2Error.setVisibility(View.GONE);
+                if (t2Section != null) t2Section.setVisibility(View.GONE);
             } else if (state.isSuccess()) {
-                if (errorView != null) errorView.setVisibility(View.GONE);
-                if (flashsale != null) flashsale.setVisibility(View.VISIBLE);
-                if (topic1 != null) topic1.setVisibility(View.VISIBLE);
-                if (topic2 != null) topic2.setVisibility(View.VISIBLE);
+                if (fsLoading != null) fsLoading.setVisibility(View.GONE);
+                if (fsError != null) fsError.setVisibility(View.GONE);
+                if (fsSection != null) fsSection.setVisibility(View.VISIBLE);
+                
+                if (t1Loading != null) t1Loading.setVisibility(View.GONE);
+                if (t1Error != null) t1Error.setVisibility(View.GONE);
+                if (t1Section != null) t1Section.setVisibility(View.VISIBLE);
+                
+                if (t2Loading != null) t2Loading.setVisibility(View.GONE);
+                if (t2Error != null) t2Error.setVisibility(View.GONE);
+                if (t2Section != null) t2Section.setVisibility(View.VISIBLE);
+                
                 HomeCoreResponse data = state.getData();
                 if (data != null) {
                     if (data.getFlashSales() != null && !data.getFlashSales().isEmpty()) {
                         updateFlashsaleUI(data.getFlashSales());
+                    } else if (fsSection != null) {
+                        fsSection.setVisibility(View.GONE);
                     }
                     if (data.getTopics() != null && data.getTopics().size() >= 2) {
                         updateTopicUI(findViewById(R.id.topic_section_1), data.getTopics().get(0));
                         updateTopicUI(findViewById(R.id.topic_section_2), data.getTopics().get(1));
+                    } else {
+                        if (t1Section != null) t1Section.setVisibility(View.GONE);
+                        if (t2Section != null) t2Section.setVisibility(View.GONE);
                     }
                 }
             } else if (state.isError() || state.isEmpty()) {
-                if (flashsale != null) flashsale.setVisibility(View.GONE);
-                if (topic1 != null) topic1.setVisibility(View.GONE);
-                if (topic2 != null) topic2.setVisibility(View.GONE);
-                if (errorView != null) {
-                    errorView.setVisibility(View.VISIBLE);
-                    android.widget.TextView tvError = findViewById(R.id.tv_core_error);
-                    if (tvError != null) tvError.setText(state.isError() ? state.getMessage() : "Không có dữ liệu");
-                }
+                if (fsLoading != null) fsLoading.setVisibility(View.GONE);
+                if (fsSection != null) fsSection.setVisibility(View.GONE);
+                if (fsError != null) fsError.setVisibility(View.VISIBLE);
+                
+                if (t1Loading != null) t1Loading.setVisibility(View.GONE);
+                if (t1Section != null) t1Section.setVisibility(View.GONE);
+                if (t1Error != null) t1Error.setVisibility(View.VISIBLE);
+                
+                if (t2Loading != null) t2Loading.setVisibility(View.GONE);
+                if (t2Section != null) t2Section.setVisibility(View.GONE);
+                if (t2Error != null) t2Error.setVisibility(View.VISIBLE);
             }
         });
 
         viewModel.getBrandsData().observe(this, state -> {
+            View loadingView = findViewById(R.id.layout_brands_loading);
             View sectionView = findViewById(R.id.topic_brand_section);
             View errorView = findViewById(R.id.layout_brands_error);
             View divider = findViewById(R.id.divider_brands);
+            
             if (state.isLoading()) {
-                // Keep current state
+                if (loadingView != null) loadingView.setVisibility(View.VISIBLE);
+                if (sectionView != null) sectionView.setVisibility(View.GONE);
+                if (errorView != null) errorView.setVisibility(View.GONE);
             } else if (state.isSuccess()) {
+                if (loadingView != null) loadingView.setVisibility(View.GONE);
                 if (errorView != null) errorView.setVisibility(View.GONE);
                 if (sectionView != null) sectionView.setVisibility(View.VISIBLE);
                 if (divider != null) divider.setVisibility(View.VISIBLE);
@@ -211,12 +247,11 @@ public class HomeActivity extends AppCompatActivity {
                     updateBrandsUI(data.getBrands());
                 }
             } else if (state.isError() || state.isEmpty()) {
+                if (loadingView != null) loadingView.setVisibility(View.GONE);
                 if (sectionView != null) sectionView.setVisibility(View.GONE);
-                if (divider != null) divider.setVisibility(View.GONE);
+                if (divider != null) divider.setVisibility(View.VISIBLE);
                 if (errorView != null) {
                     errorView.setVisibility(View.VISIBLE);
-                    android.widget.TextView tvError = findViewById(R.id.tv_brands_error);
-                    if (tvError != null) tvError.setText(state.isError() ? state.getMessage() : "Không có dữ liệu");
                 }
             }
         });

--- a/android-studio-app/app/src/main/java/com/example/uitpayapp/home/HomeViewModel.java
+++ b/android-studio-app/app/src/main/java/com/example/uitpayapp/home/HomeViewModel.java
@@ -59,13 +59,13 @@ public class HomeViewModel extends ViewModel {
                 if (response.isSuccessful() && response.body() != null) {
                     coreData.setValue(UiState.success(response.body()));
                 } else {
-                    coreData.setValue(UiState.error("Không kết nối được server (Lỗi " + response.code() + ")", null));
+                    coreData.setValue(UiState.error("Không kết nối được server", null));
                 }
             }
 
             @Override
             public void onFailure(Call<HomeCoreResponse> call, Throwable t) {
-                coreData.setValue(UiState.error("Không kết nối được server: " + t.getMessage(), null));
+                coreData.setValue(UiState.error("Không kết nối được server", null));
             }
         });
     }
@@ -82,7 +82,7 @@ public class HomeViewModel extends ViewModel {
                         brandsData.setValue(UiState.success(response.body()));
                     }
                 } else {
-                    brandsData.setValue(UiState.error("Không tải được danh sách thương hiệu", null));
+                    brandsData.setValue(UiState.error("Không kết nối được server", null));
                 }
             }
 

--- a/android-studio-app/app/src/main/res/drawable/favorite_border_24px.xml
+++ b/android-studio-app/app/src/main/res/drawable/favorite_border_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#EE4D2D"
+      android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35zM7.5,5C5.53,5 4,6.53 4,8.5c0,2.67 2.76,5.16 7.02,8.97l0.98,0.88 0.98,-0.88C17.24,13.66 20,11.17 20,8.5 20,6.53 18.47,5 16.5,5c-1.54,0 -3.04,0.99 -3.57,2.36h-1.87C10.54,5.99 9.04,5 7.5,5z"/>
+</vector>

--- a/android-studio-app/app/src/main/res/drawable/favorite_filled_24px.xml
+++ b/android-studio-app/app/src/main/res/drawable/favorite_filled_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#EE4D2D">
+  <path
+      android:fillColor="#EE4D2D"
+      android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>

--- a/android-studio-app/app/src/main/res/layout/activity_favorite.xml
+++ b/android-studio-app/app/src/main/res/layout/activity_favorite.xml
@@ -68,32 +68,39 @@
             android:background="?attr/selectableItemBackground" />
     </LinearLayout>
 
-    <!-- Danh sách Quán ăn Yêu thích chính -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvMainFavorite"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/bottom_container"
-        app:layout_constraintTop_toBottomOf="@+id/layoutFilters" />
+        app:layout_constraintTop_toBottomOf="@+id/layoutFilters">
 
-    <!-- Màn hình trống (Empty State) xe đẩy đồ ăn màu cam (Ảnh 1) -->
-    <LinearLayout
-        android:id="@+id/layoutEmptyState"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:layout_marginTop="40dp"
-        android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/layoutFilters">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <!-- Bạn có thể thay thế bằng ảnh xe đẩy màu cam tương tự -->
-        <ImageView
-            android:layout_width="110dp"
-            android:layout_height="110dp"
-            android:src="@android:drawable/ic_dialog_map"
-            app:tint="#FFA000" />
-    </LinearLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvMainFavorite"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <LinearLayout
+                android:id="@+id/layoutEmptyState"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:layout_marginTop="40dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="110dp"
+                    android:layout_height="110dp"
+                    android:src="@android:drawable/ic_dialog_map"
+                    app:tint="#FFA000" />
+            </LinearLayout>
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/bottom_container"

--- a/android-studio-app/app/src/main/res/layout/activity_favorite_horizontal_holder.xml
+++ b/android-studio-app/app/src/main/res/layout/activity_favorite_horizontal_holder.xml
@@ -19,14 +19,6 @@
             android:textColor="#EE4D2D"
             android:textSize="15sp"
             android:textStyle="bold" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:text="Xem thêm ›"
-            android:textColor="#9E9E9E"
-            android:textSize="13sp" />
     </RelativeLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/android-studio-app/app/src/main/res/layout/activity_favorite_item_shop.xml
+++ b/android-studio-app/app/src/main/res/layout/activity_favorite_item_shop.xml
@@ -38,19 +38,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tvFreeshipTag"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="#00BFA5"
-            android:paddingHorizontal="4dp"
-            android:paddingVertical="1dp"
-            android:text="X9 FREESHIP"
-            android:textColor="@android:color/white"
-            android:textSize="9sp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+        <ImageView
+            android:id="@+id/ivHorizontalFavoriteHeart"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_margin="4dp"
+            android:src="@drawable/favorite_filled_24px"
+            app:tint="#EE4D2D"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
@@ -59,13 +56,6 @@
         android:layout_marginTop="6dp"
         android:gravity="center_vertical"
         android:orientation="horizontal">
-
-        <ImageView
-            android:layout_width="12dp"
-            android:layout_height="12dp"
-            android:src="@android:drawable/button_onoff_indicator_on"
-            app:tint="#FF9800"
-            android:layout_marginEnd="3dp"/>
 
         <TextView
             android:id="@+id/tvHorizontalName"
@@ -78,17 +68,5 @@
             android:textSize="13sp"
             android:textStyle="bold" />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/tvHorizontalDiscount"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:background="@android:drawable/toast_frame"
-        android:paddingHorizontal="4dp"
-        android:paddingVertical="1dp"
-        android:text="Mã giảm 19%"
-        android:textColor="#EE4D2D"
-        android:textSize="10sp" />
 
 </LinearLayout>

--- a/android-studio-app/app/src/main/res/layout/activity_favorite_item_vertical.xml
+++ b/android-studio-app/app/src/main/res/layout/activity_favorite_item_vertical.xml
@@ -84,13 +84,13 @@
                     android:paddingVertical="2dp"
                     android:paddingHorizontal="6dp"/>
 
-                <TextView
-                    android:id="@+id/tvFavoriteHeart"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                <ImageView
+                    android:id="@+id/ivVerticalFavoriteHeart"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
                     android:layout_alignParentEnd="true"
-                    android:text="❤️"
-                    android:textSize="14sp"/>
+                    android:src="@drawable/favorite_filled_24px"
+                    app:tint="#EE4D2D"/>
             </RelativeLayout>
         </LinearLayout>
     </LinearLayout>

--- a/android-studio-app/app/src/main/res/layout/activity_home.xml
+++ b/android-studio-app/app/src/main/res/layout/activity_home.xml
@@ -272,37 +272,29 @@
                 android:layout_height="8dp"
                 android:background="#F0F0F0" />
 
-            <!-- Error State cho Core (Flash Sale & Topics) -->
-            <LinearLayout
-                android:id="@+id/layout_core_error"
+            <!-- Flash Sale States -->
+            <FrameLayout
+                android:id="@+id/layout_flashsale_loading"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="150dp"
+                android:visibility="visible">
+                <ProgressBar android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center" android:indeterminateTint="#F24405" />
+            </FrameLayout>
+            <LinearLayout
+                android:id="@+id/layout_flashsale_error"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
                 android:orientation="vertical"
                 android:gravity="center"
-                android:padding="32dp"
                 android:background="#FFFFFF"
                 android:visibility="gone">
-                
-                <ImageView
-                    android:layout_width="64dp"
-                    android:layout_height="64dp"
-                    android:src="@android:drawable/ic_dialog_alert"
-                    app:tint="#F44336" />
-                    
-                <TextView
-                    android:id="@+id/tv_core_error"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Không kết nối được server"
-                    android:textColor="#757575"
-                    android:textSize="14sp" />
-                    
+                <ImageView android:layout_width="40dp" android:layout_height="40dp" android:src="@android:drawable/ic_dialog_alert" app:tint="#F44336" />
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="Không kết nối được server" android:textColor="#757575" />
             </LinearLayout>
-
             <include
                 android:id="@+id/flashsale_section"
-                layout="@layout/layout_flashsale_section" />
+                layout="@layout/layout_flashsale_section"
+                android:visibility="gone" />
 
             <View
                 android:id="@+id/divider_brands"
@@ -310,20 +302,27 @@
                 android:layout_height="8dp"
                 android:background="#F0F0F0" />
 
+            <!-- Brands States -->
+            <FrameLayout
+                android:id="@+id/layout_brands_loading"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:visibility="visible">
+                <ProgressBar android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center" android:indeterminateTint="#F24405" />
+            </FrameLayout>
             <!-- Error State cho Brands -->
             <LinearLayout
                 android:id="@+id/layout_brands_error"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="150dp"
                 android:orientation="vertical"
                 android:gravity="center"
-                android:padding="32dp"
                 android:background="#FFFFFF"
                 android:visibility="gone">
                 
                 <ImageView
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
                     android:src="@android:drawable/ic_dialog_alert"
                     app:tint="#F44336" />
                     
@@ -333,32 +332,71 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="Không kết nối được server"
-                    android:textColor="#757575"
-                    android:textSize="14sp" />
-                    
+                    android:textColor="#757575" />
             </LinearLayout>
 
             <include
                 android:id="@+id/topic_brand_section"
-                layout="@layout/layout_topic_section" />
+                layout="@layout/layout_topic_section"
+                android:visibility="gone" />
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="8dp"
                 android:background="#F0F0F0" />
 
+            <!-- Topic 1 States -->
+            <FrameLayout
+                android:id="@+id/layout_topic1_loading"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:visibility="visible">
+                <ProgressBar android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center" android:indeterminateTint="#F24405" />
+            </FrameLayout>
+            <LinearLayout
+                android:id="@+id/layout_topic1_error"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:background="#FFFFFF"
+                android:visibility="gone">
+                <ImageView android:layout_width="40dp" android:layout_height="40dp" android:src="@android:drawable/ic_dialog_alert" app:tint="#F44336" />
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="Không kết nối được server" android:textColor="#757575" />
+            </LinearLayout>
             <include
                 android:id="@+id/topic_section_1"
-                layout="@layout/layout_topic_section" />
+                layout="@layout/layout_topic_section"
+                android:visibility="gone" />
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="8dp"
                 android:background="#F0F0F0" />
 
+            <!-- Topic 2 States -->
+            <FrameLayout
+                android:id="@+id/layout_topic2_loading"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:visibility="visible">
+                <ProgressBar android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center" android:indeterminateTint="#F24405" />
+            </FrameLayout>
+            <LinearLayout
+                android:id="@+id/layout_topic2_error"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:background="#FFFFFF"
+                android:visibility="gone">
+                <ImageView android:layout_width="40dp" android:layout_height="40dp" android:src="@android:drawable/ic_dialog_alert" app:tint="#F44336" />
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="Không kết nối được server" android:textColor="#757575" />
+            </LinearLayout>
             <include
                 android:id="@+id/topic_section_2"
-                layout="@layout/layout_topic_section" />
+                layout="@layout/layout_topic_section"
+                android:visibility="gone" />
 
             <View
                 android:layout_width="match_parent"


### PR DESCRIPTION
- Thêm pull-to-refresh và đồng bộ khi chuyển tab để làm mới danh sách.
- Chuyển icon trái tim sang dạng viền/đặc, giữ nguyên vị trí quán khi bỏ thích cho tới khi tải lại.
- Thu gọn dropdown danh mục thành "Tất cả ▼" với kích thước cố định.
- Tối giản UI thẻ "Đặt nhiều nhất" (xóa tag freeship, mã giảm giá, dấu gạch vàng và chữ Xem thêm).
- Sử dụng mock data đồng bộ với màn hình Trang chủ.